### PR TITLE
Preload OHLC data for daily pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,17 @@ MONGO_URI=mongodb://localhost:27017/
 }
 
 ```
+
+## 🔄 Daily Market Pipeline Workflow
+
+`daily_market_pipeline.py`는 지정한 날짜 구간의 모든 OHLC 데이터를 시작 시점에
+한 번에 로드합니다. 각 심볼은 `START_DATE - 250`일부터 `END_DATE`까지의 데이터를
+`fetch_historical_klines`로 불러온 후 `calculate_all_indicators`를 수행합니다.
+계산이 끝난 DataFrame을 날짜별로 슬라이스하여
+`prepare_market_data_documents_for_mongo`를 통해 문서를 만들고
+`upsert_daily_market_document`로 MongoDB에 저장합니다.
+
+1. 심볼 목록과 날짜 범위를 스크립트 상단에서 설정합니다.
+2. 모든 심볼의 가격 데이터를 한 번에 가져와 지표를 계산합니다.
+3. 날짜 범위를 순회하며 각 날짜의 행을 추출해 `market_data_dict`를 구성합니다.
+4. 요약 생성 후 `upsert_daily_market_document`를 호출해 저장합니다.

--- a/daily_market_pipeline.py
+++ b/daily_market_pipeline.py
@@ -1,46 +1,72 @@
 from binance.client import Client
-from common import api_key, api_secret, fetch_historical_klines, calculate_all_indicators, upsert_daily_market_document, call_gpt_community_summary, call_gpt_macro_summary, prepare_market_data_documents_for_mongo
+from common import (
+    api_key,
+    api_secret,
+    fetch_historical_klines,
+    calculate_all_indicators,
+    upsert_daily_market_document,
+    call_gpt_community_summary,
+    call_gpt_macro_summary,
+    prepare_market_data_documents_for_mongo,
+)
 from datetime import datetime, timedelta
 import time
 
 if __name__ == "__main__":
-    SYMBOLS = ['BTCUSDT', 'ETHUSDT'] # 여기에 원하는 심볼을 추가
+    SYMBOLS = ['BTCUSDT', 'ETHUSDT']  # 여기에 원하는 심볼을 추가
     INTERVAL = Client.KLINE_INTERVAL_1DAY
-    START_DATE_STR = '2023-01-01' # 시작 날짜
-    END_DATE_STR = '2023-01-05' # 종료 날짜
+    START_DATE_STR = '2023-01-01'  # 시작 날짜
+    END_DATE_STR = '2023-01-05'  # 종료 날짜
     PERPLEXITY_SLEEP_SECONDS = 3 * 60
 
     start_date = datetime.strptime(START_DATE_STR, '%Y-%m-%d').date()
     end_date = datetime.strptime(END_DATE_STR, '%Y-%m-%d').date()
 
+    binance_client = Client(api_key, api_secret)
+
+    symbol_data = {}
+    lookback_start = (start_date - timedelta(days=250)).strftime('%Y-%m-%d')
+    for symbol in SYMBOLS:
+        df = fetch_historical_klines(
+            binance_client,
+            symbol,
+            INTERVAL,
+            lookback_start,
+            END_DATE_STR,
+        )
+        if df.empty:
+            symbol_data[symbol] = df
+            continue
+        symbol_data[symbol] = calculate_all_indicators(df)
+
     # 날짜 범위 내의 모든 날짜에 대해 반복
-    for current_date in (start_date + timedelta(days=n) for n in range((end_date - start_date).days + 1)):
+    for current_date in (
+        start_date + timedelta(days=n) for n in range((end_date - start_date).days + 1)
+    ):
         date_str = current_date.strftime('%Y-%m-%d')
         market_data_dict = {}
-        for symbol in SYMBOLS:
-            lookback_start = (current_date - timedelta(days=250)).strftime('%Y-%m-%d')
-            df = fetch_historical_klines(Client(api_key, api_secret), symbol, INTERVAL, lookback_start, date_str) # 가격 데이터 가져오기
+        for symbol, df in symbol_data.items():
             if df.empty:
                 continue
-            
-            df = calculate_all_indicators(df) # 가격 데이터로 기술 지표 계산해 추가
-
-            # open_time의 date만 비교해서 해당 날짜의 모든 캔들 추출
             daily_row = df[df.index.date == current_date]
             if daily_row.empty:
                 print(f"{symbol} {date_str}에 해당하는 open_time 데이터 없음")
                 continue
-            market_data_dict[symbol] = prepare_market_data_documents_for_mongo(daily_row, symbol, INTERVAL) # 시장 데이터 문서 준비
-        
-        community_summary = call_gpt_community_summary(date_str) # 커뮤니티 요약 생성
-        macro_summary = call_gpt_macro_summary(date_str) # 거시경제 요약 생성
+            market_data_dict[symbol] = prepare_market_data_documents_for_mongo(
+                daily_row,
+                symbol,
+                INTERVAL,
+            )
+
+        community_summary = call_gpt_community_summary(date_str)  # 커뮤니티 요약 생성
+        macro_summary = call_gpt_macro_summary(date_str)  # 거시경제 요약 생성
 
         # MongoDB에 문서 삽입 또는 업데이트
         upsert_daily_market_document(
             date_str,
             market_data=market_data_dict,
             community_summary=community_summary,
-            macro_summary=macro_summary
+            macro_summary=macro_summary,
         )
         print(f"{current_date} 저장 완료 (market_data count: {len(market_data_dict)})")
 
@@ -49,4 +75,4 @@ if __name__ == "__main__":
             print(f"--- {PERPLEXITY_SLEEP_SECONDS // 60}분 휴식 ---\n")
             time.sleep(PERPLEXITY_SLEEP_SECONDS)
 
-    print("통합 파이프라인 실행 완료.") 
+    print("통합 파이프라인 실행 완료.")


### PR DESCRIPTION
## Summary
- refactor `daily_market_pipeline` to fetch historical data once per symbol
- use a single Binance client and precomputed DataFrames
- loop over dates and slice data for MongoDB updates
- document new pipeline workflow in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877a2f8d504832db2f2461058056083